### PR TITLE
Reverse progress ring functionality

### DIFF
--- a/Legacy/UICircularRing.swift
+++ b/Legacy/UICircularRing.swift
@@ -172,6 +172,17 @@ import UIKit
         didSet { ringLayer.setNeedsDisplay() }
     }
 
+    /**
+     Determines if the progress ring should animate in reverse
+
+     ## Important ##
+     Default = false
+
+    */
+    open var isReverse: Bool = false {
+        didSet { ringLayer.isReverse = isReverse }
+    }
+
     // MARK: Outer Ring properties
 
     /**

--- a/Legacy/UICircularRingLayer.swift
+++ b/Legacy/UICircularRingLayer.swift
@@ -39,6 +39,7 @@ class UICircularRingLayer: CAShapeLayer {
     @NSManaged var value: CGFloat
     @NSManaged var minValue: CGFloat
     @NSManaged var maxValue: CGFloat
+    @NSManaged var isReverse: Bool
 
     /// the delegate for the value, is notified when value changes
     @NSManaged weak var ring: UICircularRing!
@@ -134,13 +135,23 @@ class UICircularRingLayer: CAShapeLayer {
     override func action(forKey event: String) -> CAAction? {
         if event == "value" && animated {
             let animation = CABasicAnimation(keyPath: "value")
-            animation.fromValue = presentation()?.value(forKey: "value")
+            if isReverse {
+                animation.fromValue = maxValue
+                animation.toValue = 0
+            } else {
+                animation.fromValue = presentation()?.value(forKey: "value")
+            }
             animation.timingFunction = CAMediaTimingFunction(name: animationTimingFunction)
             animation.duration = animationDuration
             return animation
         } else if UICircularRingLayer.isAnimatableProperty(event) && shouldAnimateProperties {
             let animation = CABasicAnimation(keyPath: event)
-            animation.fromValue = presentation()?.value(forKey: event)
+            if isReverse {
+                animation.fromValue = maxValue
+                animation.toValue = 0
+            } else {
+                animation.fromValue = presentation()?.value(forKey: event)
+            }
             animation.timingFunction = CAMediaTimingFunction(name: animationTimingFunction)
             animation.duration = propertyAnimationDuration
             return animation

--- a/Legacy/UICircularTimerRing.swift
+++ b/Legacy/UICircularTimerRing.swift
@@ -29,6 +29,15 @@ final public class UICircularTimerRing: UICircularRing {
     // MARK: Members
 
     /**
+     The initial value to display for the ring.
+
+     Default is 0.
+     */
+    public var value: CGFloat = 0 {
+        didSet { ringLayer.value = value }
+    }
+
+    /**
      The formatter used when formatting the value into a string for the ring.
 
      Default formatter is of type `UICircularTimerRingFormatter`.
@@ -129,7 +138,7 @@ final public class UICircularTimerRing: UICircularRing {
         super.initialize()
         ringLayer.ring = self
         ringLayer.minValue = 0
-        ringLayer.value = 0
+        ringLayer.value = value
         ringLayer.maxValue = time.float
         ringLayer.valueFormatter = valueFormatter
         ringLayer.animationTimingFunction = .linear


### PR DESCRIPTION
A hacky way to add functionality that reverses the progress ring: if the `isReverse` var is set to `true`, simply reverse the animation.

Note: this is not the "right" way to implement this functionality; this is a hack that I quickly threw together as I did not have enough time to come up with a proper solution.